### PR TITLE
Fix broken links in documentation that go to different sections.

### DIFF
--- a/docs-src/descriptions/active-state.jade
+++ b/docs-src/descriptions/active-state.jade
@@ -80,11 +80,9 @@ pre
 p.
   This issue applies not only to properties,
   but also to all stateful observables
-  (like #[a(href='take') take], #[a(href='diff') diff], #[a(href='scan') scan] etc.).
+  (like #[a(href='#take') take], #[a(href='#diff') diff], #[a(href='#scan') scan] etc.).
   In rare cases you might need to activate an observable by adding
   a dummy subscriber, to solve this issue. It's ok if you really need this,
   but don't overuse that pattern. For example
   #[tt obs.map(sideEffect).onEnd(function(){})] is a bad code,
   you should do #[tt obs.onValue(sideEffect)] istead.
-
-

--- a/docs-src/descriptions/create.jade
+++ b/docs-src/descriptions/create.jade
@@ -30,7 +30,7 @@ p.
   to create general purpose streams,
   but it doesn't give control over the #[a(href='#active-state') active state]
   of the stream. If you want to have that control, you should use
-  #[a(href='from-binder') fromBinder] or #[a(href='#from-sub-unsub') fromSubUnsub].
+  #[a(href='#from-binder') fromBinder] or #[a(href='#from-sub-unsub') fromSubUnsub].
 
 
 
@@ -296,7 +296,7 @@ p.
 
 p.
   You can also provide an #[b transform] function, which will work the same way as in
-  #[a(href='from-event') fromEvent] or #[a(href='as-kefir-stream') asKefirStream].
+  #[a(href='#from-event') fromEvent] or #[a(href='#as-kefir-stream') asKefirStream].
 
 pre(title='example')
   :escapehtml
@@ -474,4 +474,3 @@ pre(title='console output')
 pre(title='events in time').
   result:  ----1X
 div
-

--- a/docs-src/descriptions/multiple-sources.jade
+++ b/docs-src/descriptions/multiple-sources.jade
@@ -494,7 +494,7 @@ div
 
 
 +descr-method('flat-map-concat', 'flatMapConcat', 'obs.flatMapConcat([fn])').
-  Like #[a(href='flat-map-first') flatMapFirst], but instead of ignoring new observables
+  Like #[a(href='#flat-map-first') flatMapFirst], but instead of ignoring new observables
   (if previous one still alive), it adds them to the queue.
   Then, when current source ends, it takes the oldest observable from the queue,
   and switches to it.
@@ -535,7 +535,7 @@ div
 
 
 +descr-method('flat-map-with-concurrency-limit', 'flatMapConcurLimit', 'obs.flatMapConcurLimit([fn], limit)').
-  Like #[a(href='flat-map-concat') flatMapConcat], but with configurable number of concurent sources,
+  Like #[a(href='#flat-map-concat') flatMapConcat], but with configurable number of concurent sources,
   in other words #[b flatMapConcat] is #[tt flatMapConcurLimit(fn, 1)].
 
 pre(title='example').


### PR DESCRIPTION
Fix links that are suppose to direct the user to other sections instead of directing them to a 404. Small simple fix :).