### PR TITLE
make the classes Pool and Bus publicly available

### DIFF
--- a/src/multiple-sources.js
+++ b/src/multiple-sources.js
@@ -178,6 +178,7 @@ Observable.prototype.concat = function(other) {
 function Pool() {
   _AbstractPool.call(this);
 }
+Kefir.Pool = Pool;
 
 inherit(Pool, _AbstractPool, {
 
@@ -207,6 +208,7 @@ Kefir.pool = function() {
 function Bus() {
   _AbstractPool.call(this);
 }
+Kefir.Bus = Bus;
 
 inherit(Bus, _AbstractPool, {
 
@@ -239,6 +241,7 @@ inherit(Bus, _AbstractPool, {
 Kefir.bus = function() {
   return new Bus();
 }
+
 
 
 

--- a/src/multiple-sources.js
+++ b/src/multiple-sources.js
@@ -246,7 +246,6 @@ Kefir.bus = function() {
 
 
 
-
 // .flatMap()
 
 function FlatMap(source, fn, options) {

--- a/test/specs/bus.coffee
+++ b/test/specs/bus.coffee
@@ -7,6 +7,11 @@ describe 'bus', ->
 
   it 'should return stream', ->
     expect(Kefir.bus()).toBeStream()
+    expect(new Kefir.Bus()).toBeStream()
+
+  it 'should return bus', ->
+    expect(Kefir.bus()).toBeBus()
+    expect(new Kefir.Bus()).toBeBus()
 
   it 'should not be ended', ->
     expect(Kefir.bus()).toEmit []

--- a/test/specs/pool.coffee
+++ b/test/specs/pool.coffee
@@ -5,6 +5,11 @@ describe 'pool', ->
 
   it 'should return stream', ->
     expect(Kefir.pool()).toBeStream()
+    expect(new Kefir.Pool()).toBeStream()
+
+  it 'should return pool', ->
+    expect(Kefir.pool()).toBePool()
+    expect(new Kefir.Pool()).toBePool()
 
   it 'should activate sources', ->
     a = stream()

--- a/test/test-helpers.coffee
+++ b/test/test-helpers.coffee
@@ -92,6 +92,12 @@ beforeEach ->
     toBeStream: ->
       @message = -> "Expected #{@actual.toString()} to be instance of Stream"
       @actual instanceof Kefir.Stream
+    toBePool: ->
+      @message = -> "Expected #{@actual.toString()} to be instance of Pool"
+      @actual instanceof Kefir.Pool
+    toBeBus: ->
+      @message = -> "Expected #{@actual.toString()} to be instance of Bus"
+      @actual instanceof Kefir.Bus
 
     toBeActive: -> @actual._active
 


### PR DESCRIPTION
Kefir has functions like [`Kefir.pool`](https://github.com/pozadi/kefir/blob/c7b60ae9550a75e5d565c5f8e6f34ab7c8cfb998/src/multiple-sources.js#L197) and [`Kefir.bus`](https://github.com/pozadi/kefir/blob/c7b60ae9550a75e5d565c5f8e6f34ab7c8cfb998/src/multiple-sources.js#L239). What they return are actually new instances of the classes [`Pool`](https://github.com/pozadi/kefir/blob/c7b60ae9550a75e5d565c5f8e6f34ab7c8cfb998/src/multiple-sources.js#L178) and [`Bus`](https://github.com/pozadi/kefir/blob/c7b60ae9550a75e5d565c5f8e6f34ab7c8cfb998/src/multiple-sources.js#L207). But users of Kefir have no access to these constructors.

Was there a reason for hiding them? Even if you find these 'factory functions' more elegant as a way to instantiate these types of streams, I would still prefer to have access to the constructors for purposes of documentation, type-checking, and so on.

Note that these are not just stream implementations. They have an extended public interface. I do not, for example, propose making the [`FlatMap`](https://github.com/pozadi/kefir/blob/c7b60ae9550a75e5d565c5f8e6f34ab7c8cfb998/src/multiple-sources.js#L249) constructor public.